### PR TITLE
[DEV] Fix grid display when orientation is Landscape

### DIFF
--- a/components/ImageCard.tsx
+++ b/components/ImageCard.tsx
@@ -10,11 +10,14 @@ type ItemProps = {
 
 export default function ImageCard({id, uri, sizeType, isSquare}: ItemProps) {
   const screenWidth = Dimensions.get('window').width;
+  const screenHeight = Dimensions.get('window').height;
   const isLarge:boolean = sizeType == 'large';
   const aspectRatio:number = isSquare ? 1/2 : 1;
 
   const sT = () => {
     switch(sizeType){
+      case 'small':
+        return { width: screenWidth/7, height: screenHeight/4 }
       case 'medium':
         return { width: screenWidth, aspectRatio: 1 };
       case 'large':

--- a/screens/HomeScreen/HomeScreen.tsx
+++ b/screens/HomeScreen/HomeScreen.tsx
@@ -101,20 +101,23 @@ export default function HomeScreen() {
 
   const ContentGridGallery = () => {
     return isMyGalleryEmpty
-      ? <FlatList
-          showsVerticalScrollIndicator={false}
-          data={myGallery}
-          numColumns={isPortrait ? 3 : 6}
-          key={isPortrait ? 3 : 6}
-          renderItem={({item}) =>
-            <SelectableItem
-              id={item['id']}
-              uri={item['uri']}
-              title={item['title']}
-              size={item['size']}
-            />
-          }
-        />
+      ? <View style={ isPortrait ? {} : {alignItems: 'center'}}>
+          <FlatList
+            showsVerticalScrollIndicator={false}
+            data={myGallery}
+            numColumns={isPortrait ? 3 : 6}
+            key={isPortrait ? 3 : 6}
+            renderItem={({item}) =>
+              <SelectableItem
+                id={item['id']}
+                uri={item['uri']}
+                title={item['title']}
+                size={item['size']}
+                sizeImage={isPortrait ? "" : "small"}
+              />
+            }
+          />
+        </View>
       : <EmptyGallery />
   }
 


### PR DESCRIPTION
### Actual behavior
When phone orientation is Landscape, the grid view is not reordered

### What is the new behavior
When the phone orientation is Landscape, the grid view is reordered 6 items per lines

### Impacted Components in Application
* Component affected by this PR

### Note
No additional notes
